### PR TITLE
Add support for .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.{c,h}]
+charset = utf-8
+trim_trailing_whitespace = false
+end_of_line = lf
+insert_final_newline = true
+indent_size = 2
+indent_style = space
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/rx-unix/src/main.c
+++ b/rx-unix/src/main.c
@@ -38,14 +38,12 @@ unsigned short xmodem_calc_crc(char* ptr, short count)
     {
       crc = crc ^ (unsigned short) *ptr++ << 8;
       i=8;
-      do
-	{
-	  if (crc & 0x8000)
-	    crc=crc<<1^0x1021;
-	  else
-	    crc=crc<<1;
-	}
-      while(--i);
+      do {
+        if (crc & 0x8000)
+          crc = crc << 1 ^ 0x1021;
+        else
+          crc = crc << 1;
+      } while (--i);
     }
   return crc;
 }
@@ -164,21 +162,21 @@ int xmodem_receive(void)
   while (state!=END)
     {
       switch(state)
-	{
-	case START:
-	  xmodem_state_start();
-	  break;
-	case BLOCK:
-	  xmodem_state_block();
-	  break;
-	case CHECK:
-	  xmodem_state_check();
-	  break;
-	case REBLOCK:
-	  break;
-	case END:
-	  break;
-	}
+        {
+        case START:
+          xmodem_state_start();
+          break;
+        case BLOCK:
+          xmodem_state_block();
+          break;
+        case CHECK:
+          xmodem_state_check();
+          break;
+        case REBLOCK:
+          break;
+        case END:
+          break;
+        }
     }
   
   // We're done.

--- a/tx-msdos/src/xmodem-send.c
+++ b/tx-msdos/src/xmodem-send.c
@@ -39,14 +39,12 @@ unsigned short xmodem_calc_crc(char* ptr, short count)
     {
       crc = crc ^ (unsigned short) *ptr++ << 8;
       i=8;
-      do
-	{
-	  if (crc & 0x8000)
-	    crc=crc<<1^0x1021;
-	  else
-	    crc=crc<<1;
-	}
-      while(--i);
+      do {
+        if (crc & 0x8000)
+          crc = crc << 1 ^ 0x1021;
+        else
+          crc = crc << 1;
+      } while (--i);
     }
   return crc;
 }
@@ -67,22 +65,22 @@ void xmodem_send(void)
   
   while (state!=END)
     {
-      switch(state)
-	{
-	case START:
-	  xmodem_state_start();
-	  break;
-	case BLOCK:
-	  xmodem_state_block();
-	  break;
-	case CHECK:
-	  xmodem_state_check();
-	  break;
-	case REBLOCK:
-	  break;
-	case END:
-	  break;
-	}
+      switch (state)
+        {
+          case START:
+            xmodem_state_start();
+            break;
+          case BLOCK:
+            xmodem_state_block();
+            break;
+          case CHECK:
+            xmodem_state_check();
+            break;
+          case REBLOCK:
+            break;
+          case END:
+            break;
+        }
     }
   
   free(buf);
@@ -101,14 +99,14 @@ void xmodem_state_start()
       delay(1);
       wait_time--;
       if (int14_data_waiting()!=0)
-	{
-	  if (int14_read_byte()=='C')
-	    {
-	      state=BLOCK;
-	      printf("Starting Transfer.\n");
-	      return;
-	    }
-	}
+        {
+          if (int14_read_byte()=='C')
+            {
+              state=BLOCK;
+              printf("Starting Transfer.\n");
+              return;
+            }
+        }
     }
   printf("Trying Again...\n");
 }
@@ -129,7 +127,7 @@ void xmodem_state_block(void)
       int14_send_byte(0xFF-block_num); // 0xFF - BLOCK # (simple checksum)
 
       for (i=0;i<512;i++)     // Send the data
-	int14_send_byte(buf[i]);
+        int14_send_byte(buf[i]);
 
       calced_crc=xmodem_calc_crc(buf,512);
       int14_send_byte((calced_crc>>8));       // CRC Hi
@@ -155,25 +153,25 @@ void xmodem_state_check(void)
     {
       b=int14_read_byte();
       switch (b)
-	{
-	case 0x06: // ACK
-	  printf("ACK!\n");
-	  block_num++;
-	  block_num&=0xff;
-	  state=BLOCK;
-	  xmodem_set_next_sector();  // so if we're at end, it can be overridden.
-	  break;
-	case 0x15: // NAK
-	  printf("NAK!\n");
-	  state=BLOCK;  // Resend.
-	  break;
-	case 0x18: // CAN
-	  printf("CANCEL!\n");
-	  state=END;   // end.
-	  break;
-	default:
-	  printf("Unknown Byte: 0x%02d: %c",b,b);
-	}
+        {
+        case 0x06: // ACK
+          printf("ACK!\n");
+          block_num++;
+          block_num&=0xff;
+          state=BLOCK;
+          xmodem_set_next_sector();  // so if we're at end, it can be overridden.
+          break;
+        case 0x15: // NAK
+          printf("NAK!\n");
+          state=BLOCK;  // Resend.
+          break;
+        case 0x18: // CAN
+          printf("CANCEL!\n");
+          state=END;   // end.
+          break;
+        default:
+          printf("Unknown Byte: 0x%02d: %c",b,b);
+        }
     }
 }
 
@@ -186,15 +184,15 @@ void xmodem_set_next_sector(void)
     {
       sector=1;
       if (head>=geometry.h)
-	{
-	  head=0;
-	  if (cylinder>geometry.c)
-	    state=END;
-	  else
-	    cylinder++;
-	}
+        {
+          head=0;
+          if (cylinder>geometry.c)
+            state=END;
+          else
+            cylinder++;
+        }
       else
-	head++;
+        head++;
     }
   else
     sector++;


### PR DESCRIPTION
Hi!

I made a [fork](https://github.com/desaster/disk-xfer-rb) of the wonderful `disk-xfer` for use with [DEC Rainbow](https://en.wikipedia.org/wiki/Rainbow_100).

While writing my own additions, I wanted to keep the code style consistent and avoid creating any extra mess. The code style of `disk-xfer` is a bit different to what I'm personally used to, so to make it easier to work with I added an `.editorconfig` file.

[.editorconfig](https://editorconfig.org/) is supported by most editors either natively, or through an extension. The `.editorconfig` added in this PR adds just some basic settings:

```ini
root = true

[*.{c,h}]
charset = utf-8
trim_trailing_whitespace = false # existing codebase has some trailing whitespaces
end_of_line = lf # assuming both sub-projects are intended to be built on unix
insert_final_newline = true
indent_size = 2 # existing indentation
indent_style = space # space, not tab

# Makefiles are always tabs
[Makefile]
indent_style = tab
```

Additionally this PR has a few changes to change mixed tab indentations into spaces.