### PR TITLE
Add makefile for tx-msdos and top-level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+SUBDIRS=rx-unix tx-msdos
+
+all: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@
+
+.PHONY: all $(SUBDIRS)

--- a/tx-msdos/Makefile
+++ b/tx-msdos/Makefile
@@ -1,0 +1,47 @@
+TARGET_EXEC ?= tx.com
+
+BUILD_DIR ?= ./build
+SRC_DIRS ?= ./src
+
+CC=owcc
+LINK=wlink
+
+SRCS := $(shell find $(SRC_DIRS) -name *.cpp -or -name *.c -or -name *.s)
+OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
+DEPS := $(OBJS:.o=.d)
+
+CFLAGS=-bdos -mcmodel=t -s -march=i86 -W -Wall -Wextra
+LDFLAGS=
+
+INC_DIRS := $(shell find $(SRC_DIRS) -type d)
+INC_FLAGS := $(addprefix -I,$(INC_DIRS))
+
+CPPFLAGS ?= $(INC_FLAGS)
+
+$(BUILD_DIR)/$(TARGET_EXEC): $(OBJS)
+	$(LINK) system com name $@ file {$(OBJS)}
+
+# assembly
+$(BUILD_DIR)/%.s.o: %.s
+	$(MKDIR_P) $(dir $@)
+	$(AS) $(ASFLAGS) -c $< -o $@
+
+# c source
+$(BUILD_DIR)/%.c.o: %.c
+	$(MKDIR_P) $(dir $@)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+# c++ source
+$(BUILD_DIR)/%.cpp.o: %.cpp
+	$(MKDIR_P) $(dir $@)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+
+
+.PHONY: clean
+
+clean:
+	$(RM) -r $(BUILD_DIR)
+
+-include $(DEPS)
+
+MKDIR_P ?= mkdir -p

--- a/tx-msdos/clean.sh
+++ b/tx-msdos/clean.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo Cleaning project.
-rm -rf *.obj *.mk* *.com *.map *.err *.lk*


### PR DESCRIPTION
This should make it more straightforward to build the entire project.

The top level makefile will call `make` on both `tx-msdos` and `rx-msdos` subdirectories.

The `Makefile` for `tx-msdos` assumes that the OpenWatcom environment is properly set with `owsetenv.sh`

Unfortunately, the top-level Makefile does not support cleaning the subdirectories.